### PR TITLE
Use standard integer types (u_int64_t -> uint64_t)

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -19,7 +20,7 @@ static void sigsegv_handler(int sig) {
 	siglongjmp(sigsegv_handler_jmp_buf, 1);
 }
 
-static bool safe_read_write(u_int64_t * addr, u_int64_t * data, bool write) {
+static bool safe_read_write(uint64_t * addr, uint64_t * data, bool write) {
 	struct sigaction oldact;
 	struct sigaction act;
 	memset(&act, 0, sizeof(struct sigaction));
@@ -57,10 +58,10 @@ static void undervolt_it(uv_list_t * uv, void * data) {
 	undervolt_ctx * ctx = data;
 
 	static int mask = 0x800;
-	u_int64_t uvint = ((u_int64_t) (mask - absf(uv->value) * 1.024f + 0.5f)
+	uint64_t uvint = ((uint64_t) (mask - absf(uv->value) * 1.024f + 0.5f)
 		<< 21) & 0xffffffff;
-	u_int64_t rdval = 0x8000001000000000 | ((u_int64_t) uv->index << 40);
-	u_int64_t wrval = rdval | 0x100000000 | uvint;
+	uint64_t rdval = 0x8000001000000000 | ((uint64_t) uv->index << 40);
+	uint64_t wrval = rdval | 0x100000000 | uvint;
 
 	bool write_success = !ctx->write ||
 		wr(ctx->config, MSR_ADDR_VOLTAGE, wrval);
@@ -138,9 +139,9 @@ static bool tdp(config_t * config, bool * nl, bool write) {
 		void * mem = config->tdp_mem + (MEM_ADDR_TDP & MAP_MASK);
 		const char * errstr = NULL;
 
-		u_int64_t msr_limit;
-		u_int64_t mchbar_limit;
-		u_int64_t units;
+		uint64_t msr_limit;
+		uint64_t mchbar_limit;
+		uint64_t units;
 		if (rd(config, MSR_ADDR_TDP, msr_limit)) {
 			if (!safe_read_write(mem, &mchbar_limit, false)) {
 				errstr = "Segmentation fault";
@@ -161,15 +162,15 @@ static bool tdp(config_t * config, bool * nl, bool write) {
 
 			if (write) {
 				int max_tdp = 0x7fff / power_unit;
-				u_int64_t masked = msr_limit & 0xffff8000ffff8000;
-				u_int64_t short_term = config->tdp_short_term < 0 ? 0 :
+				uint64_t masked = msr_limit & 0xffff8000ffff8000;
+				uint64_t short_term = config->tdp_short_term < 0 ? 0 :
 					config->tdp_short_term > max_tdp ? max_tdp :
 					config->tdp_short_term * power_unit;
-				u_int64_t long_term = config->tdp_long_term < 0 ? 0 :
+				uint64_t long_term = config->tdp_long_term < 0 ? 0 :
 					config->tdp_long_term > max_tdp ? max_tdp :
 					config->tdp_long_term * power_unit;
-				u_int64_t value = masked | (short_term << 32) | long_term;
-				u_int64_t time;
+				uint64_t value = masked | (short_term << 32) | long_term;
+				uint64_t time;
 				if (config->tdp_short_time_window > 0) {
 					masked = value & 0xff01ffffffffffff;
 					time = tdp_from_seconds(config->tdp_short_time_window,
@@ -229,9 +230,9 @@ static bool tjoffset(config_t * config, bool * nl, bool write) {
 		const char * errstr = NULL;
 
 		if (write) {
-			u_int64_t limit;
+			uint64_t limit;
 			if (rd(config, MSR_ADDR_TEMPERATURE, limit)) {
-				u_int64_t offset = abs(config->tjoffset);
+				uint64_t offset = abs(config->tjoffset);
 				offset = offset > 0x3f ? 0x3f : offset;
 				limit = (limit & 0xffffffffc0ffffff) | (offset << 24);
 				if (!wr(config, MSR_ADDR_TEMPERATURE, limit)) {
@@ -245,7 +246,7 @@ static bool tjoffset(config_t * config, bool * nl, bool write) {
 		if (errstr) {
 			printf("Failed to write temperature offset: %s\n", errstr);
 		} else if (nl) {
-			u_int64_t limit;
+			uint64_t limit;
 			if (rd(config, MSR_ADDR_TEMPERATURE, limit)) {
 				int offset = (limit & 0x3f000000) >> 24;
 				printf("Critical offset: -%d°C\n", offset);


### PR DESCRIPTION
Use uint64_t from stdint.h instead of the non-standard u_int64_t. This fixes
compilation issues with musl libc.