### PR TITLE
short_term_enable and long_term_enable were flipped

### DIFF
--- a/main.c
+++ b/main.c
@@ -203,8 +203,8 @@ static bool tdp(config_t * config, bool * nl, bool write) {
 				}
 				int short_term = ((msr_limit >> 32) & 0x7fff) / power_unit;
 				int long_term = (msr_limit & 0x7fff) / power_unit;
-				bool short_term_enabled = !!((msr_limit >> 15) & 1);
-				bool long_term_enabled = !!((msr_limit >> 47) & 1);
+				bool short_term_enabled = !!((msr_limit >> 47) & 1);
+				bool long_term_enabled = !!((msr_limit >> 15) & 1);
 				float short_term_window = tdp_to_seconds(msr_limit >> 48,
 					time_unit);
 				float long_term_window = tdp_to_seconds(msr_limit >> 16,


### PR DESCRIPTION
This commit fixes a bug in determining whether short- and long-term power limit are enabled.