### PR TITLE
intel-undervolt: Apply undervolt at the beginning of the daemon mode

### DIFF
--- a/modes.c
+++ b/modes.c
@@ -40,6 +40,7 @@ int daemon_mode() {
 	config_t * config = load_config(NULL, NULL);
 	struct sigaction act;
 	unsigned int i = 0;
+	bool nl = false;
 	cpu_policy_t * cpu_policy = NULL;
 
 	if (config && config->interval <= 0) {
@@ -53,6 +54,11 @@ int daemon_mode() {
 		act.sa_handler = sigusr1_handler;
 		sigaction(SIGUSR1, &act, NULL);
 
+		if (!undervolt(config, &nl, true)) {
+			printf("failed to undervolt, aborting\n");
+			free_config(config);
+			return false;
+		}
 		reload_config = false;
 		while (true) {
 			if (reload_config) {


### PR DESCRIPTION
[BUG]
Even with intel-undervolt-loop.service enabled, "intel-undervolt read"
shows only power limit and jtemp is applied, not undervolt.

[CAUSE]
Daemon mode just skips all the undervolt setting.

[FIX]
Apply the undervolt setting before entering into the main loop.
And if we failed to apply undervolt setting, there should be something
wrong and we should just abort the program.

Signed-off-by: Qu Wenruo <wqu@suse.com>