### PR TITLE
intel-undervolt.service: wanted by suspend-then-hibernate

### DIFF
--- a/intel-undervolt.service.in
+++ b/intel-undervolt.service.in
@@ -1,10 +1,10 @@
 [Unit]
 Description=Intel Undervolt Service
-After=multi-user.target suspend.target hibernate.target hybrid-sleep.target
+After=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
 
 [Service]
 Type=oneshot
 ExecStart=%BINDIR%/intel-undervolt apply
 
 [Install]
-WantedBy=multi-user.target suspend.target hibernate.target hybrid-sleep.target
+WantedBy=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target


### PR DESCRIPTION
systemd doesn't use the existing suspend and hibernate targets and uses a separate target for suspend-then-hibernate. Add this target to the list of targets that undervolt runs on resume.