### PR TITLE
Prevent systemd launching service when virtualized

### DIFF
--- a/intel-undervolt-loop.service.in
+++ b/intel-undervolt-loop.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Intel Undervolt Loop Service
 After=multi-user.target
+ConditionVirtualization=no
 
 [Service]
 Type=simple

--- a/intel-undervolt.service.in
+++ b/intel-undervolt.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Intel Undervolt Service
 After=multi-user.target suspend.target hibernate.target hybrid-sleep.target
+ConditionVirtualization=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
I sometimes boot my linux environment within a virtualisation container, as it lives on an external SSD.

When virtualised, the intel-undervolt service fails --- it doesn't make sense to run the service when virtualised anyway.

This pull adds a condition check to the systemd service files checking if running in a virtualised or container environment.