### PR TITLE
Updated README.md and add information about compatible CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 intel-undervolt is a tool for undervolting and throttling limits alteration for Intel CPUs.
 
-Undervolting works on Haswell and newer CPUs and based on the content of
+Undervolting works from Haswell up to Ice Lake. Tiger Lake and above are not compatible. Based on the content of
 [this article](https://github.com/mihic/linux-intel-undervolt).
 
 ## Disclaimer


### PR DESCRIPTION
Added information to README.md that intel-undervolt only works on Intel CPUs from Haswell up to Ice Lake. Tiger Lake and above are not compatible. See [https://community.intel.com/t5/Processors/11th-gen-tiger-lake-undervolting-disabled-by-intel/td-p/1245398](https://community.intel.com/t5/Processors/11th-gen-tiger-lake-undervolting-disabled-by-intel/td-p/1245398)