### PR TITLE
Add missing sys/time.h include for musl

### DIFF
--- a/measure.c
+++ b/measure.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/time.h>
 
 #define DIR_HWMON "/sys/class/hwmon"
 #define BUFSZ 80


### PR DESCRIPTION
Musl libc doesn't include `suseconds_t` by default, so it is necessary to import `sys/time.h` for intel-undervolt to work on musl-based distros.