### PR TITLE
Correct undervolt index for System Agent (at least for modern hw)

### DIFF
--- a/intel-undervolt.conf
+++ b/intel-undervolt.conf
@@ -10,8 +10,7 @@ enable no
 undervolt 0 'CPU' 0
 undervolt 1 'GPU' 0
 undervolt 2 'CPU Cache' 0
-undervolt 3 'System Agent' 0
-undervolt 4 'Analog I/O' 0
+undervolt 4 'System Agent' 0
 
 # Power Limits Alteration
 # Usage: power ${domain} ${short_power_value} ${long_power_value}


### PR DESCRIPTION
sys agent uv always returns a "values don't match" error on modern hardware (tested on icelake cpu)

this is because index is wrong, correct index is **4**, i have no idea what 3 is

leaving this here so that users on modern hw are aware of this if they cannot set SA uv.
this would need some checks to be implemented to set correct indexes in code