### PR TITLE
Fix FreeBSD build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 CFLAGS =
 EXTRA_CFLAGS = -Wall -Wextra
 DESTDIR =

--- a/configure
+++ b/configure
@@ -65,7 +65,7 @@ sedarg() {
   printf '%s' "s,^\($1 =\).*$,\1 $2,"
 }
 
-sed Makefile.in \
+sed \
 -e "`sedcond SYSTEMD "$enable_systemd"`" \
 -e "`sedcond ELOGIND "$enable_elogind"`" \
 -e "`sedcond OPENRC "$enable_openrc"`" \
@@ -74,7 +74,7 @@ sed Makefile.in \
 -e "`sedarg RUNSTATEDIR "$runstatedir"`" \
 -e "`sedarg UNITDIR "$unitdir"`" \
 -e "`sedarg ELOGINDDIR "$eloginddir"`" \
-> Makefile || exit 1
+Makefile.in > Makefile || exit 1
 
 echo "Enable systemd: $enable_systemd"
 echo "Enable elogind: $enable_elogind"


### PR DESCRIPTION
Remove linuxisms on intel-undervolt build process
- fix sed syntax in configure script
- made gcc optional if the CC variable set when calling make